### PR TITLE
Vim complains if space between assignment operator

### DIFF
--- a/after/syntax/c.vim
+++ b/after/syntax/c.vim
@@ -1,12 +1,12 @@
-syntax match cOperator "<=" conceal cchar = ≤
-syntax match cOperator ">=" conceal cchar = ≥
-syntax match cOperator "==" conceal cchar = ═
-syntax match cOperator "!=" conceal cchar = ≠
-syntax match cOperator "<<" conceal cchar = «
-syntax match cOperator ">>" conceal cchar = »
-syntax match cOperator "__" conceal cchar = ‗
+syntax match cOperator "<=" conceal cchar=≤
+syntax match cOperator ">=" conceal cchar=≥
+syntax match cOperator "==" conceal cchar=═
+syntax match cOperator "!=" conceal cchar=≠
+syntax match cOperator "<<" conceal cchar=«
+syntax match cOperator ">>" conceal cchar=»
+syntax match cOperator "__" conceal cchar=‗
 
 hi  link cOperator Operator
 hi! link Conceal   Operator
 
-setlocal conceallevel = 1
+setlocal conceallevel=1


### PR DESCRIPTION
Error log:
```
Error detected while processing /usr/share/vim/vimrc[25]../usr/share/vim/vim90/syntax/syntax.vim[43]..BufRead Autocommands for "*.c"..function dist#ft#FTlpc[11]..FileType Autocommands for "*"..Syntax Autocommands for "*"..function <SNR>4_SynSet[25]..script /users/ashfaqur/vim-ligatures/after/syntax/c.vim:
line    1:
E475: Invalid argument: cOperator "<=" conceal cchar = ≤
line    2:
E475: Invalid argument: cOperator ">=" conceal cchar = ≥
line    3:
E475: Invalid argument: cOperator "==" conceal cchar = ═
line    4:
E475: Invalid argument: cOperator "!=" conceal cchar = ≠
line    5:
E475: Invalid argument: cOperator "<<" conceal cchar = «
line    6:
E475: Invalid argument: cOperator ">>" conceal cchar = »
line    7:
E475: Invalid argument: cOperator "__" conceal cchar = ‗
line   12:
E521: Number required after =: conceallevel =
line    1:
E475: Invalid argument: cOperator "<=" conceal cchar = ≤
line    2:
E475: Invalid argument: cOperator ">=" conceal cchar = ≥
line    3:
E475: Invalid argument: cOperator "==" conceal cchar = ═
line    4:
E475: Invalid argument: cOperator "!=" conceal cchar = ≠
line    5:
E475: Invalid argument: cOperator "<<" conceal cchar = «
line    6:
E475: Invalid argument: cOperator ">>" conceal cchar = »
line    7:
E475: Invalid argument: cOperator "__" conceal cchar = ‗
line   12:
E521: Number required after =: conceallevel =
```

Vim version:
```
VIM - Vi IMproved 9.0 (2022 Jun 28, compiled May 10 2022 08:40:37)
Included patches: 1-749
Modified by team+vim@tracker.debian.org
Compiled by team+vim@tracker.debian.org
Huge version without GUI.  Features included (+) or not (-):
+acl               +file_in_path      +mouse_urxvt       -tag_any_white
+arabic            +find_in_path      +mouse_xterm       +tcl
+autocmd           +float             +multi_byte        +termguicolors
+autochdir         +folding           +multi_lang        +terminal
-autoservername    -footer            -mzscheme          +terminfo
-balloon_eval      +fork()            +netbeans_intg     +termresponse
+balloon_eval_term +gettext           +num64             +textobjects
-browse            -hangul_input      +packages          +textprop
++builtin_terms    +iconv             +path_extra        +timers
+byte_offset       +insert_expand     +perl              +title
+channel           +ipv6              +persistent_undo   -toolbar
+cindent           +job               +popupwin          +user_commands
-clientserver      +jumplist          +postscript        +vartabs
-clipboard         +keymap            +printer           +vertsplit
+cmdline_compl     +lambda            +profile           +vim9script
+cmdline_hist      +langmap           -python            +viminfo
+cmdline_info      +libcall           +python3           +virtualedit
+comments          +linebreak         +quickfix          +visual
+conceal           +lispindent        +reltime           +visualextra
+cryptv            +listcmds          +rightleft         +vreplace
+cscope            +localmap          +ruby              +wildignore
+cursorbind        +lua               +scrollbind        +wildmenu
+cursorshape       +menu              +signs             +windows
+dialog_con        +mksession         +smartindent       +writebackup
+diff              +modify_fname      +sodium            -X11
+digraphs          +mouse             -sound             -xfontset
-dnd               -mouseshape        +spell             -xim
-ebcdic            +mouse_dec         +startuptime       -xpm
+emacs_tags        +mouse_gpm         +statusline        -xsmp
+eval              -mouse_jsbterm     -sun_workshop      -xterm_clipboard
+ex_extra          +mouse_netterm     +syntax            -xterm_save
+extra_search      +mouse_sgr         +tag_binary
-farsi             -mouse_sysmouse    -tag_old_static
   system vimrc file: "$VIM/vimrc"
     user vimrc file: "$HOME/.vimrc"
 2nd user vimrc file: "~/.vim/vimrc"
      user exrc file: "$HOME/.exrc"
       defaults file: "$VIMRUNTIME/defaults.vim"
  fall-back for $VIM: "/usr/share/vim"
Compilation: gcc -c -I. -Iproto -DHAVE_CONFIG_H -Wdate-time -g -O2 -fdebug-prefix-map=/build/vim-s9rYnH/vim-9.0.0749=. -fstack-protector-strong -Wformat -Werror=format-security -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1
Linking: gcc -L. -Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now -fstack-protector-strong -rdynamic -Wl,-export-dynamic -Wl,-E -Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now -Wl,--as-needed -o vim -lm -ltinfo -lselinux -lsodium -lrt -lacl -lattr -lgpm -ldl -L/usr/lib -llua5.2 -Wl,-E -fstack-protector-strong -L/usr/local/lib -L/usr/lib/x86_64-linux-gnu/perl/5.30/CORE -lperl -ldl -lm -lpthread -lcrypt -L/usr/lib/python3.8/config-3.8-x86_64-linux-gnu -lpython3.8 -lcrypt -lpthread -ldl -lutil -lm -lm -L/usr/lib/x86_64-linux-gnu -ltcl8.6 -ldl -lz -lpthread -lm -lruby-2.7 -lm -L/usr/lib
```